### PR TITLE
added media queries squashing

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -15,7 +15,7 @@ var consolidate  = require("gulp-consolidate");
 var minifyCss    = require('gulp-minify-css');
 var iconfont     = require('gulp-iconfont');
 var lodash       = require('lodash');
-var cmq          = require('gulp-combine-media-queries');
+var combineMq    = require('gulp-combine-mq');
 
 // Paths
 var buildPath  = './build/'
@@ -28,7 +28,7 @@ var fontPath   = 'assets/font/';
 gulp.task('build-sass', function () {
   return rubySass(sassPath + 'main.sass')
     .on('error', rubySass.logError)
-    .pipe(cmq())
+    .pipe(combineMq({ beautify: false }))
     .pipe(postcss([ autoprefixer({ browsers: ['last 2 version'] }) ]))
     .pipe(minifyCss({keepSpecialComments: 0}))
     .pipe(gulp.dest(buildPath));
@@ -42,7 +42,7 @@ gulp.task('build-stylus', function () {
       'include css': true
      }))
     .pipe(rename('main.css'))
-    .pipe(cmq())
+    .pipe(combineMq({ beautify: false }))
     .pipe(postcss([ autoprefixer({ browsers: ['last 2 version'] }) ]))
     .pipe(minifyCss())
     .pipe(gulp.dest(buildPath));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -15,6 +15,7 @@ var consolidate  = require("gulp-consolidate");
 var minifyCss    = require('gulp-minify-css');
 var iconfont     = require('gulp-iconfont');
 var lodash       = require('lodash');
+var cmq          = require('gulp-combine-media-queries');
 
 // Paths
 var buildPath  = './build/'
@@ -27,6 +28,7 @@ var fontPath   = 'assets/font/';
 gulp.task('build-sass', function () {
   return rubySass(sassPath + 'main.sass')
     .on('error', rubySass.logError)
+    .pipe(cmq())
     .pipe(postcss([ autoprefixer({ browsers: ['last 2 version'] }) ]))
     .pipe(minifyCss({keepSpecialComments: 0}))
     .pipe(gulp.dest(buildPath));
@@ -40,6 +42,7 @@ gulp.task('build-stylus', function () {
       'include css': true
      }))
     .pipe(rename('main.css'))
+    .pipe(cmq())
     .pipe(postcss([ autoprefixer({ browsers: ['last 2 version'] }) ]))
     .pipe(minifyCss())
     .pipe(gulp.dest(buildPath));

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "autoprefixer-core": "^5.2.1",
-    "gulp-combine-media-queries": "^0.2.0",
+    "gulp-combine-mq": "^0.4.0",
     "gulp-consolidate": "^0.1.2",
     "gulp-iconfont": "^3.0.2",
     "gulp-minify-css": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "devDependencies": {
     "autoprefixer-core": "^5.2.1",
+    "gulp-combine-media-queries": "^0.2.0",
     "gulp-consolidate": "^0.1.2",
     "gulp-iconfont": "^3.0.2",
     "gulp-minify-css": "^1.2.0",


### PR DESCRIPTION
I found out recently that gulp-minify-css which is just a wrapper around clean-css doesn't actually merge media queries. This can be easily solved by making use of [gulp-combine-media-queries](https://www.npmjs.com/package/gulp-combine-media-queries).

I haven't tested it thoroughly, but I already started using it on another project and it seems to be working flawlessly, rendering the resulting css substantially smaller.
