### PR TITLE
Fix __getDepthMap() for LibSass

### DIFF
--- a/src/instyle.sass
+++ b/src/instyle.sass
@@ -98,6 +98,14 @@ $__inTagReplace: '@' !default
 
 @function __getDepthMap($selector, $current)
   $depthMap: ()
+  
+  // Make sure the $current list is correctly parsed while using libsass.
+  $currentList: ()
+  @each $parent in $current
+    $currentList: append($currentList, $parent, comma)
+  @if length($currentList) > 0
+    $current: $currentList
+    
   @each $parent in $current
     // Save maximum length of matched compound to compare relevancy
     $parentIndex: index($current, $parent)


### PR DESCRIPTION
The `__getDepthMap()` function makes LibSass hang while compiling. That's because the `index()` function doesn't seem to work exactly the same in LibSass (up to 3.4.3) as in Ruby Sass (up to 3.4.23), especially while looking for values that contain spaces inside comma-separated lists. Re-parsing the `$current` list before trying to obtain the `$parentIndex` fixes the issue.